### PR TITLE
Make staticcheck happy

### DIFF
--- a/cloutapi.go
+++ b/cloutapi.go
@@ -32,7 +32,7 @@ func main() {
 	viper.AddConfigPath(".")
 	err := viper.ReadInConfig()
 	if err != nil {
-		panic(fmt.Errorf("Error reading config file: %w", err))
+		panic(fmt.Errorf("error reading config file: %w", err))
 	}
 
 	myauth = doLogin(


### PR DESCRIPTION
Before fix:
```
% staticcheck
cloutapi.go:35:9: error strings should not be capitalized (ST1005)
```