### PR TITLE
Initial flag support

### DIFF
--- a/config.properties.example
+++ b/config.properties.example
@@ -5,5 +5,3 @@ password=secretPa$$word
 
 client_name=safespring-test-klient
 client_origin=https://safespring.com
-debug=true
-create=true


### PR DESCRIPTION
Replace "create" config entry with --dry-run flag, and support a --debug flag instead of having to modify the config to flip debugging on and off.