### PR TITLE
Fixes endpoint URL for clientoptionset and adds config YAML to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 cloutility-api-client
 config.properties
 cloutility-api-client.properties
+cloutility-api-client.yaml

--- a/cloutility/clientOptionSet.go
+++ b/cloutility/clientOptionSet.go
@@ -29,7 +29,7 @@ func (c *AuthenticatedClient) GetClientOptionSet(bUnitID int) ([]ClientOptionSet
 	)
 
 	// validate the base url to create the endpoint
-	endpoint := "/v1/bunits" + fmt.Sprintf("%d", bUnitID) + "/defaultserver/clientoptionsets"
+	endpoint := "/v1/bunits/" + fmt.Sprintf("%d", bUnitID) + "/defaultserver/clientoptionsets"
 	resp, err := c.apiRequest(endpoint, http.MethodGet, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error requesting clientOptionSets: %s", err)


### PR DESCRIPTION
There is a small error in the clientoptionset URL that this pull request fixes.

Additionally, cloutility-api-client.yaml has been added to .gitignore in order to prevent accidental commits of credentials.